### PR TITLE
fix(blog-markdown)

### DIFF
--- a/app/Livewire/AllBlogs.php
+++ b/app/Livewire/AllBlogs.php
@@ -5,7 +5,7 @@ namespace App\Livewire;
 use App\Models\Blog;
 use Livewire\Component;
 use Livewire\WithPagination;
-use Parsedown;
+use Illuminate\Support\Str;
 
 class AllBlogs extends Component
 {
@@ -20,8 +20,11 @@ class AllBlogs extends Component
 
     public function render()
     {
-        $parsedown = new Parsedown();
         $blogs = Blog::latest()->paginate(5);
-        return view('livewire.all-blogs', compact('blogs', 'parsedown'))->layout('layouts.app');
+        $blogs->getCollection()->transform(function ($blog) {
+            $blog->content = Str::markdown($blog->content);
+            return $blog;
+        });
+        return view('livewire.all-blogs', compact('blogs'))->layout('layouts.app');
     }
 }


### PR DESCRIPTION
This PR fixes the markdown in blog posts, allowing Rank 4 admins to use markdown in blog posts again.